### PR TITLE
add more IMAGE_ envs, trim output to last 1KB

### DIFF
--- a/internal/provider/exec_test_data_source_test.go
+++ b/internal/provider/exec_test_data_source_test.go
@@ -36,6 +36,18 @@ func TestAccExecTestDataSource(t *testing.T) {
 				resource.TestMatchResourceAttr("data.oci_exec_test.test", "output", regexp.MustCompile("hello\n")),
 			),
 		}, {
+			Config: fmt.Sprintf(`data "oci_exec_test" "env" {
+  digest = "cgr.dev/chainguard/wolfi-base@%s"
+
+  script = "echo IMAGE_NAME=$${IMAGE_NAME} IMAGE_REPOSITORY=$${IMAGE_REPOSITORY} IMAGE_REGISTRY=$${IMAGE_REGISTRY}"
+}`, d.String()),
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("data.oci_exec_test.env", "digest", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
+				resource.TestCheckResourceAttr("data.oci_exec_test.env", "id", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
+				resource.TestCheckResourceAttr("data.oci_exec_test.env", "exit_code", "0"),
+				resource.TestCheckResourceAttr("data.oci_exec_test.env", "output", fmt.Sprintf("IMAGE_NAME=cgr.dev/chainguard/wolfi-base@%s IMAGE_REPOSITORY=chainguard/wolfi-base IMAGE_REGISTRY=cgr.dev\n", d.String())),
+			),
+		}, {
 			Config: fmt.Sprintf(`data "oci_exec_test" "fail" {
   digest = "cgr.dev/chainguard/wolfi-base@%s"
 


### PR DESCRIPTION
The first 1KB isn't usually as useful as the last 1KB 😆

We could also just log the whole output and see if terraform trims it.

`IMAGE_REPOSITORY` and `IMAGE_REGISTRY` are used in our k8s tests, along with `IMAGE_TAG`, which we still need an answer for.