### PR TITLE
exec_test: support working_dir

### DIFF
--- a/docs/data-sources/exec_test.md
+++ b/docs/data-sources/exec_test.md
@@ -23,6 +23,7 @@ Exec test data source
 ### Optional
 
 - `timeout_seconds` (Number) Timeout for the test in seconds (default is 5 minutes)
+- `working_dir` (String) Working directory for the test
 
 ### Read-Only
 

--- a/internal/provider/exec_test_data_source.go
+++ b/internal/provider/exec_test_data_source.go
@@ -35,6 +35,7 @@ type ExecTestDataSourceModel struct {
 	Digest         types.String `tfsdk:"digest"`
 	Script         types.String `tfsdk:"script"`
 	TimeoutSeconds types.Int64  `tfsdk:"timeout_seconds"`
+	WorkingDir     types.String `tfsdk:"working_dir"`
 
 	ExitCode  types.Int64  `tfsdk:"exit_code"`
 	Output    types.String `tfsdk:"output"`
@@ -65,6 +66,10 @@ func (d *ExecTestDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 				MarkdownDescription: "Timeout for the test in seconds (default is 5 minutes)",
 				Optional:            true,
 				Validators:          []validator.Int64{positiveIntValidator{}},
+			},
+			"working_dir": schema.StringAttribute{
+				MarkdownDescription: "Working directory for the test",
+				Optional:            true,
 			},
 
 			// TODO: platform?
@@ -136,6 +141,7 @@ func (d *ExecTestDataSource) Read(ctx context.Context, req datasource.ReadReques
 		"IMAGE_REPOSITORY="+repo,
 		"IMAGE_REGISTRY="+registry,
 	)
+	cmd.Dir = data.WorkingDir.ValueString()
 	out, err := cmd.CombinedOutput()
 	if len(out) > 1024 {
 		out = out[len(out)-1024:] // trim output to the last 1KB

--- a/internal/provider/exec_test_data_source_test.go
+++ b/internal/provider/exec_test_data_source_test.go
@@ -29,7 +29,7 @@ func TestAccExecTestDataSource(t *testing.T) {
 
   script = "docker run --rm $${IMAGE_NAME} echo hello | grep hello"
 }`, d.String()),
-			Check: resource.ComposeTestCheckFunc(
+			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("data.oci_exec_test.test", "digest", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
 				resource.TestCheckResourceAttr("data.oci_exec_test.test", "id", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
 				resource.TestCheckResourceAttr("data.oci_exec_test.test", "exit_code", "0"),
@@ -41,7 +41,7 @@ func TestAccExecTestDataSource(t *testing.T) {
 
   script = "echo IMAGE_NAME=$${IMAGE_NAME} IMAGE_REPOSITORY=$${IMAGE_REPOSITORY} IMAGE_REGISTRY=$${IMAGE_REGISTRY}"
 }`, d.String()),
-			Check: resource.ComposeTestCheckFunc(
+			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("data.oci_exec_test.env", "digest", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
 				resource.TestCheckResourceAttr("data.oci_exec_test.env", "id", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
 				resource.TestCheckResourceAttr("data.oci_exec_test.env", "exit_code", "0"),
@@ -63,6 +63,19 @@ func TestAccExecTestDataSource(t *testing.T) {
 	  script = "sleep 6"
 	}`, d.String()),
 			ExpectError: regexp.MustCompile(`Test for ref\ncgr.dev/chainguard/wolfi-base@sha256:[0-9a-f]{64}\ntimed out after 1 seconds`),
+		}, {
+			Config: fmt.Sprintf(`data "oci_exec_test" "working_dir" {
+		  digest = "cgr.dev/chainguard/wolfi-base@%s"
+		  working_dir = "${path.module}/../../"
+
+		  script = "grep 'Terraform Provider for OCI operations' README.md"
+		}`, d.String()),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("data.oci_exec_test.working_dir", "digest", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
+				resource.TestCheckResourceAttr("data.oci_exec_test.working_dir", "id", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
+				resource.TestCheckResourceAttr("data.oci_exec_test.working_dir", "exit_code", "0"),
+				resource.TestCheckResourceAttr("data.oci_exec_test.working_dir", "output", "# Terraform Provider for OCI operations\n"),
+			),
 		}},
 	})
 


### PR DESCRIPTION
I don't know how to make `${path.module}` the default, if you have any ideas let me know.

Fixes #40 