### PR TITLE
exec_test: on failure, print full output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,0 @@
-## 0.1.0 (Unreleased)
-
-FEATURES:


### PR DESCRIPTION
The `.output` attribute remains trimmed to 1KB if it's larger than that, since storing the full output in TF state can be needlessly slow, and if the test fails you won't be able to get that output anyway.

(We should maybe drop `exit_code` for the same reason: if it's anything but `0` the datasource will fail and you won't be able to have dependent resources that effectively read the `exit_code` value).