### PR TITLE
Revert "tag: accept multiple tags per resource (#74)"

### DIFF
--- a/docs/resources/tag.md
+++ b/docs/resources/tag.md
@@ -18,11 +18,7 @@ Tag an existing image by digest.
 ### Required
 
 - `digest_ref` (String) Image ref by digest to apply the tag to.
-
-### Optional
-
-- `tag` (String, Deprecated) Tag to apply to the image.
-- `tags` (List of String) Tags to apply to the image.
+- `tag` (String) Tag to apply to the image.
 
 ### Read-Only
 

--- a/internal/provider/tag_resource_test.go
+++ b/internal/provider/tag_resource_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccTagResource(t *testing.T) {
-	repo, cleanup := ocitesting.SetupRepository(t, "repo")
+	repo, cleanup := ocitesting.SetupRepository(t, "test")
 	defer cleanup()
 
 	// Push an image to the local registry.
@@ -30,7 +30,7 @@ func TestAccTagResource(t *testing.T) {
 	}
 	dig1 := ref1.Context().Digest(d1.String())
 
-	// Push another image to the local registry.
+	// Push an image to the local registry.
 	ref2 := repo.Tag("2")
 	t.Logf("Using ref2: %s", ref2)
 	img2, err := random.Image(1024, 1)
@@ -46,108 +46,36 @@ func TestAccTagResource(t *testing.T) {
 	}
 	dig2 := ref2.Context().Digest(d2.String())
 
-	// Create the resource tagging dig1 three tags.
-	want1 := fmt.Sprintf("%s:foo@%s", repo, d1)
+	want1 := fmt.Sprintf("%s:test@%s", repo, d2)
+	want2 := fmt.Sprintf("%s:test2@%s", repo, d2)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
+			// Create and Read testing
 			{
 				Config: fmt.Sprintf(`resource "oci_tag" "test" {
 				  digest_ref = %q
-				  tags       = ["foo", "bar", "baz"]
+				  tag        = "test"
 				}`, dig1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("oci_tag.test", "tagged_ref", want1),
 					resource.TestCheckResourceAttr("oci_tag.test", "id", want1),
 				),
 			},
-		},
-	})
-
-	// The digest should be tagged with all three tags.
-	for _, want := range []string{"foo", "bar", "baz"} {
-		desc, err := remote.Get(repo.Tag(want))
-		if err != nil {
-			t.Errorf("failed to get image with tag %q: %v", want, err)
-		}
-		if desc.Digest != d1 {
-			t.Errorf("image with tag %q has wrong digest: got %s, want %s", want, desc.Digest, d1)
-		}
-	}
-
-	// Point the tags to another digest.
-	want2 := fmt.Sprintf("%s:foo@%s", repo, d2)
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
+			// Update and Read testing
 			{
 				Config: fmt.Sprintf(`resource "oci_tag" "test" {
-				  digest_ref = %q
-				  tags       = ["foo", "bar", "baz"]
-				}`, dig2),
+					digest_ref = %q
+					tag        = "test2"
+				  }`, dig2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("oci_tag.test", "tagged_ref", want2),
 					resource.TestCheckResourceAttr("oci_tag.test", "id", want2),
 				),
 			},
+			// Delete testing automatically occurs in TestCase
 		},
-	})
-
-	// The second digest should be tagged with all three tags.
-	for _, want := range []string{"foo", "bar", "baz"} {
-		desc, err := remote.Get(repo.Tag(want))
-		if err != nil {
-			t.Errorf("failed to get image with tag %q: %v", want, err)
-		}
-		if desc.Digest != d2 {
-			t.Errorf("image with tag %q has wrong digest: got %s, want %s", want, desc.Digest, d2)
-		}
-	}
-
-	// Add a fourth tag.
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`resource "oci_tag" "test" {
-					  digest_ref = %q
-					  tags       = ["foo", "bar", "baz", "qux"]
-					}`, dig2),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("oci_tag.test", "tagged_ref", want2),
-					resource.TestCheckResourceAttr("oci_tag.test", "id", want2),
-				),
-			},
-		},
-	})
-
-	// The second digest should be tagged with all three tags.
-	for _, want := range []string{"foo", "bar", "baz", "qux"} {
-		desc, err := remote.Get(repo.Tag(want))
-		if err != nil {
-			t.Errorf("failed to get image with tag %q: %v", want, err)
-		}
-		if desc.Digest != d2 {
-			t.Errorf("image with tag %q has wrong digest: got %s, want %s", want, desc.Digest, d2)
-		}
-	}
-
-	// Tag the digest with the same tag multiple times, which should be allowed but warn.
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{{
-			Config: fmt.Sprintf(`resource "oci_tag" "test" {
-					  digest_ref = %q
-					  tags       = ["foo", "foo", "foo", "bar", "bar", "bar"]
-					}`, dig2),
-			Check: resource.ComposeAggregateTestCheckFunc(
-				resource.TestCheckResourceAttr("oci_tag.test", "tagged_ref", want2),
-				resource.TestCheckResourceAttr("oci_tag.test", "id", want2),
-			),
-		}},
 	})
 }

--- a/pkg/validators/tag_validator.go
+++ b/pkg/validators/tag_validator.go
@@ -10,7 +10,7 @@ import (
 // TagValidator is a string validator that checks that the string is valid OCI reference by digest.
 type TagValidator struct{}
 
-var _ validator.String = TagValidator{}
+var _ validator.String = DigestValidator{}
 
 func (v TagValidator) Description(context.Context) string {
 	return `value must be a valid OCI tag element (e.g., "latest", "v1.2.3")`


### PR DESCRIPTION
This reverts commit e4a57d90c7bec812b80eb0e69ca1d7109b48249d.

Instead of this, we'll use a new resource, `oci_tags`. This un-deprecates `tag` and removes `tags`.