### PR TITLE
fix: allow testing an index with a single image

### DIFF
--- a/internal/provider/exec_test_data_source.go
+++ b/internal/provider/exec_test_data_source.go
@@ -141,8 +141,9 @@ func (d *ExecTestDataSource) Read(ctx context.Context, req datasource.ReadReques
 		resp.Diagnostics.AddError("Invalid ref", fmt.Sprintf("Unable to parse ref %s, got error: %s", data.Digest.ValueString(), err))
 		return
 	}
+
 	// Check we can get the image before running the test.
-	if _, err := remote.Image(ref, d.popts.withContext(ctx)...); err != nil {
+	if _, err := remote.Get(ref, d.popts.withContext(ctx)...); err != nil {
 		resp.Diagnostics.AddError("Unable to fetch image", fmt.Sprintf("Unable to fetch image for ref %s, got error: %s", data.Digest.ValueString(), err))
 		return
 	}

--- a/internal/provider/structure_test_data_source.go
+++ b/internal/provider/structure_test_data_source.go
@@ -128,7 +128,7 @@ func (d *StructureTestDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 	// TODO: This should accept a platform, or fail if the ref points to an index.
-	img, err := remote.Image(ref, d.popts.withContext(ctx)...)
+	desc, err := remote.Get(ref, d.popts.withContext(ctx)...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to fetch image", fmt.Sprintf("Unable to fetch image for ref %s, got error: %s", data.Digest.ValueString(), err))
 		return
@@ -148,6 +148,12 @@ func (d *StructureTestDataSource) Read(ctx context.Context, req datasource.ReadR
 				},
 			}})
 		}
+	}
+
+	img, err := desc.Image()
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to load image", fmt.Sprintf("Unable to load image for ref %s, got error: %s", data.Digest.ValueString(), err))
+		return
 	}
 
 	if err := conds.Check(img); err != nil {

--- a/internal/provider/structure_test_data_source.go
+++ b/internal/provider/structure_test_data_source.go
@@ -128,7 +128,7 @@ func (d *StructureTestDataSource) Read(ctx context.Context, req datasource.ReadR
 		resp.Diagnostics.AddError("Invalid ref", fmt.Sprintf("Unable to parse ref %s, got error: %s", data.Digest.ValueString(), err))
 		return
 	}
-	// TODO: This should accept a platform, or fail if the ref points to an index.
+
 	desc, err := remote.Get(ref, d.popts.withContext(ctx)...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to fetch image", fmt.Sprintf("Unable to fetch image for ref %s, got error: %s", data.Digest.ValueString(), err))


### PR DESCRIPTION
* Fix the situation where an index with a single image errors out because GGCR expects a `linux/amd64` image to be present in the index.