### PR TITLE
fix oci_tag test

### DIFF
--- a/internal/provider/tag_resource_test.go
+++ b/internal/provider/tag_resource_test.go
@@ -46,7 +46,7 @@ func TestAccTagResource(t *testing.T) {
 	}
 	dig2 := ref2.Context().Digest(d2.String())
 
-	want1 := fmt.Sprintf("%s:test@%s", repo, d2)
+	want1 := fmt.Sprintf("%s:test@%s", repo, d1)
 	want2 := fmt.Sprintf("%s:test2@%s", repo, d2)
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
This seems to have been broken by a drive-by change in #75 ([here](https://github.com/chainguard-dev/terraform-provider-oci/pull/75/files#diff-fb6e9f63b063a2ff4031e9f0a960c2673752f7015be694bcc3952bbca2504b0cR43)).
 
The logic was still fine, just the test was incorrect.