### PR TITLE
use unique TF IDs for exec test resources

### DIFF
--- a/internal/provider/exec_test_data_source_test.go
+++ b/internal/provider/exec_test_data_source_test.go
@@ -33,7 +33,7 @@ func TestAccExecTestDataSource(t *testing.T) {
 }`, d.String()),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("data.oci_exec_test.test", "digest", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
-				resource.TestCheckResourceAttr("data.oci_exec_test.test", "id", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
+				resource.TestMatchResourceAttr("data.oci_exec_test.test", "id", regexp.MustCompile(".*cgr.dev/chainguard/wolfi-base@"+d.String())),
 				resource.TestCheckResourceAttr("data.oci_exec_test.test", "exit_code", "0"),
 				resource.TestCheckResourceAttr("data.oci_exec_test.test", "output", ""),
 			),
@@ -54,7 +54,7 @@ func TestAccExecTestDataSource(t *testing.T) {
 }`, d.String()),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("data.oci_exec_test.env", "digest", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
-				resource.TestCheckResourceAttr("data.oci_exec_test.env", "id", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
+				resource.TestMatchResourceAttr("data.oci_exec_test.env", "id", regexp.MustCompile(".*cgr.dev/chainguard/wolfi-base@"+d.String())),
 				resource.TestCheckResourceAttr("data.oci_exec_test.env", "exit_code", "0"),
 				resource.TestCheckResourceAttr("data.oci_exec_test.env", "output", ""),
 			),
@@ -83,7 +83,7 @@ func TestAccExecTestDataSource(t *testing.T) {
 		}`, d.String()),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("data.oci_exec_test.working_dir", "digest", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
-				resource.TestCheckResourceAttr("data.oci_exec_test.working_dir", "id", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
+				resource.TestMatchResourceAttr("data.oci_exec_test.working_dir", "id", regexp.MustCompile(".*cgr.dev/chainguard/wolfi-base@"+d.String())),
 				resource.TestCheckResourceAttr("data.oci_exec_test.working_dir", "exit_code", "0"),
 				resource.TestCheckResourceAttr("data.oci_exec_test.working_dir", "output", ""),
 			),
@@ -131,7 +131,7 @@ func TestAccExecTestDataSource_FreePort(t *testing.T) {
 `, i, d.String())
 		checks = append(checks,
 			resource.TestCheckResourceAttr(fmt.Sprintf("data.oci_exec_test.freeport-%d", i), "digest", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
-			resource.TestCheckResourceAttr(fmt.Sprintf("data.oci_exec_test.freeport-%d", i), "id", fmt.Sprintf("cgr.dev/chainguard/wolfi-base@%s", d.String())),
+			resource.TestMatchResourceAttr(fmt.Sprintf("data.oci_exec_test.freeport-%d", i), "id", regexp.MustCompile(".*cgr.dev/chainguard/wolfi-base@"+d.String())),
 		)
 	}
 


### PR DESCRIPTION
Testing a theory that oci_exec_test reusing IDs causes problems when one or another exec test fails, causing the other one for the same ID to run indefinitely and not respect its timeout.

TF IDs uniquely identify resources and datasources, so reusing the resolved digest for the ID might not be the best.

Instead, this hashes the script bytes and prepends it to the image digest, so two different tests for the same digest doesn't have the same TF ID.