### PR TITLE
add support for appending indexes with oci_append

### DIFF
--- a/internal/provider/append_resource_test.go
+++ b/internal/provider/append_resource_test.go
@@ -7,6 +7,7 @@ import (
 
 	ocitesting "github.com/chainguard-dev/terraform-provider-oci/testing"
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/validate"
@@ -88,6 +89,53 @@ func TestAccAppendResource(t *testing.T) {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+
+	// Push an index to the local registry.
+	ref3 := repo.Tag("3")
+	idx1, err := random.Index(3, 1, 3)
+	if err != nil {
+		t.Fatalf("failed to create index: %v", err)
+	}
+	if err := remote.WriteIndex(ref3, idx1); err != nil {
+		t.Fatalf("failed to write index: %v", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: fmt.Sprintf(`resource "oci_append" "test" {
+        base_image = %q
+        layers = [{
+          files = {
+            "/usr/local/test.txt" = { contents = "hello world" }
+          }
+        }]
+      }`, ref3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("oci_append.test", "base_image", ref3.String()),
+					resource.TestMatchResourceAttr("oci_append.test", "id", regexp.MustCompile(`/test@sha256:[0-9a-f]{64}$`)),
+					resource.TestCheckFunc(func(s *terraform.State) error {
+						rs := s.RootModule().Resources["oci_append.test"]
+						ref, err := name.ParseReference(rs.Primary.Attributes["image_ref"])
+						if err != nil {
+							return fmt.Errorf("failed to parse reference: %v", err)
+						}
+						idx, err := remote.Index(ref)
+						if err != nil {
+							return fmt.Errorf("failed to pull image: %v", err)
+						}
+						if err := validate.Index(idx); err != nil {
+							return fmt.Errorf("failed to validate image: %v", err)
+						}
+						return nil
+					}),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
splits the existing image only `oci_append` into 2 legs, one using the existing `image` only approach and the other with a loop appending the indexes