### PR TITLE
remove process cancelling goroutine

### DIFF
--- a/internal/provider/exec_test_data_source.go
+++ b/internal/provider/exec_test_data_source.go
@@ -187,20 +187,9 @@ func (d *ExecTestDataSource) Read(ctx context.Context, req datasource.ReadReques
 	}
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", data.Script.ValueString())
-	go func() {
-		select {
-		case <-ctx.Done():
-			if err := cmd.Process.Kill(); err != nil {
-				tflog.Error(ctx, "failed to kill process", map[string]interface{}{"error": err})
-			}
-		case <-time.After(time.Duration(timeout) * time.Second):
-			if err := cmd.Process.Kill(); err != nil {
-				tflog.Error(ctx, "failed to kill process", map[string]interface{}{"error": err})
-			}
-		}
-	}()
 	cmd.Env = env
 	cmd.Dir = data.WorkingDir.ValueString()
+
 	fullout, err := cmd.CombinedOutput()
 	data.Output = types.StringValue("") // always empty.
 


### PR DESCRIPTION
the goroutine is redundant, and blocks the actual return of the function when the ctx is done.

```
Error: -19T14:46:26.742Z [ERROR] provider.terraform-provider-oci_v0.0.17: failed to kill process: @caller=github.com/chainguard-dev/terraform-provider-oci/internal/provider/exec_test_data_source.go:194 error="os: process already finished" tf_data_source_type=oci_exec_test tf_provider_addr=registry.terraform.io/chainguard-dev/oci tf_req_id=c0da7202-2dff-f56f-aebc-de6d70d42686 @module=oci tf_rpc=ReadDataSource timestamp=2024-12-19T14:46:26.741Z
```

by removing it, we remove the duplicate cancellation handling (the timeout is already plumbed through the context), and the done signal is already handled by `exec.CommandContext`.

additionally, the process.Kill() is already handled by `exec.CommandContext`: https://cs.opensource.google/go/go/+/master:src/os/exec/exec.go;l=485