### PR TITLE
Use tarfs to implement structure test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.26.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
+	github.com/jonjohnsonjr/targz v0.0.0-20241113200849-4986e08f3fb4
 	github.com/spf13/cobra v1.9.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/jhump/protoreflect v1.15.1/go.mod h1:jD/2GMKKE6OqX8qTjhADU1e6DShO+gavG9e0Q693nKo=
+github.com/jonjohnsonjr/targz v0.0.0-20241113200849-4986e08f3fb4 h1:yzUKZR6eq4hfKkNLe2KfxOBiVHyjXny7g4bEDuiYCtY=
+github.com/jonjohnsonjr/targz v0.0.0-20241113200849-4986e08f3fb4/go.mod h1:vFsMbFCBsTclpEtIkbCOBAJj1mBsqoMtm22ibo1cG2o=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/internal/provider/structure_test_data_source_test.go
+++ b/internal/provider/structure_test_data_source_test.go
@@ -36,6 +36,15 @@ func TestAccStructureTestDataSource(t *testing.T) {
 		Size: 6,
 	})
 	_, _ = tw.Write([]byte("blah!!"))
+
+	// Test that /lib -> /usr/lib works.
+	_ = tw.WriteHeader(&tar.Header{
+		Name:     "symlink",
+		Typeflag: tar.TypeSymlink,
+		Mode:     0755,
+		Linkname: "path",
+	})
+
 	tw.Close()
 
 	l, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
@@ -94,6 +103,10 @@ func TestAccStructureTestDataSource(t *testing.T) {
     }
     files {
       path  = "/path/to/baz"
+      regex = "blah!!"
+    }
+    files {
+      path  = "/symlink/to/baz"
       regex = "blah!!"
     }
   }


### PR DESCRIPTION
Previously, we scanned through the image filesystem and matched the tar.Header.Name field against the file path given by the test. This works most of the time, but doesn't handle symlinks at all.

This change writes the entire layer tar to a temporary file, parses it with tarfs to get an fs.FS, attempts to randomly access each file from the test, and deletes the temporary file afterwards.