### PR TITLE
fix: add ref to image rules error

### DIFF
--- a/internal/provider/structure_test_data_source.go
+++ b/internal/provider/structure_test_data_source.go
@@ -211,7 +211,7 @@ func (d *StructureTestDataSource) Read(ctx context.Context, req datasource.ReadR
 	if err := conds.Check(img); err != nil {
 		data.TestedRef = basetypes.NewStringValue("")
 		data.Id = basetypes.NewStringValue("")
-		resp.Diagnostics.AddError("Image does not match rules", fmt.Sprintf("Image does not match rules:\n%s", err))
+		resp.Diagnostics.AddError("Image does not match rules", fmt.Sprintf("Image %s does not match rules:\n%s", data.Digest.ValueString(), err))
 		return
 	}
 


### PR DESCRIPTION
Gitlab creates 11 images, the error does not mention which image is failing, this makes it hard to debug: https://github.com/chainguard-images/images-private/actions/runs/16397177988/job/46331318788#step:25:5782

```
Error: -20T07:01:36.004Z [ERROR] provider.terraform-provider-oci_v0.0.23: Response contains error diagnostic: @module=sdk.proto diagnostic_severity=ERROR tf_data_source_type=oci_structure_test tf_req_id=ce256de7-8ef4-9a48-ca31-0d4f7a147c70 @caller=github.com/hashicorp/terraform-plugin-go@v0.28.0/tfprotov6/internal/diag/diagnostics.go:58 diagnostic_summary="Image does not match rules" tf_proto_version=6.9 tf_provider_addr=registry.terraform.io/chainguard-dev/oci tf_rpc=ReadDataSource
```

This change adds image ref to the error