### PR TITLE
Add structure test support for optional files, directories, and permissions

### DIFF
--- a/docs/data-sources/structure_test.md
+++ b/docs/data-sources/structure_test.md
@@ -73,3 +73,4 @@ Required:
 
 - `block` (String)
 - `override` (List of String)
+- `path` (String)

--- a/docs/data-sources/structure_test.md
+++ b/docs/data-sources/structure_test.md
@@ -30,8 +30,21 @@ Structure test data source
 
 Required:
 
+- `dirs` (List of Object) (see [below for nested schema](#nestedobjatt--conditions--dirs))
 - `env` (List of Object) (see [below for nested schema](#nestedobjatt--conditions--env))
 - `files` (List of Object) (see [below for nested schema](#nestedobjatt--conditions--files))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--conditions--permissions))
+
+<a id="nestedobjatt--conditions--dirs"></a>
+### Nested Schema for `conditions.dirs`
+
+Required:
+
+- `files_only` (Boolean)
+- `mode` (String)
+- `path` (String)
+- `recursive` (Boolean)
+
 
 <a id="nestedobjatt--conditions--env"></a>
 ### Nested Schema for `conditions.env`
@@ -48,5 +61,15 @@ Required:
 Required:
 
 - `mode` (String)
+- `optional` (Boolean)
 - `path` (String)
 - `regex` (String)
+
+
+<a id="nestedobjatt--conditions--permissions"></a>
+### Nested Schema for `conditions.permissions`
+
+Required:
+
+- `block` (String)
+- `override` (List of String)

--- a/internal/provider/append_resource.go
+++ b/internal/provider/append_resource.go
@@ -254,7 +254,7 @@ func (r *AppendResource) doAppend(ctx context.Context, data *AppendResourceModel
 
 			if f.Contents.ValueString() != "" {
 				size = int64(len(f.Contents.ValueString()))
-				mode = 0644
+				mode = 0o644
 				datarc = io.NopCloser(strings.NewReader(f.Contents.ValueString()))
 
 			} else if f.Path.ValueString() != "" {

--- a/internal/provider/append_resource_test.go
+++ b/internal/provider/append_resource_test.go
@@ -49,11 +49,11 @@ func TestAccAppendResource(t *testing.T) {
 	}
 
 	tf := filepath.Join(t.TempDir(), "test_path.txt")
-	if err := os.WriteFile(tf, []byte("hello world"), 0644); err != nil {
+	if err := os.WriteFile(tf, []byte("hello world"), 0o644); err != nil {
 		t.Fatalf("failed to write file: %v", err)
 	}
 
-	if err := os.Chmod(tf, 0755); err != nil {
+	if err := os.Chmod(tf, 0o755); err != nil {
 		t.Fatalf("failed to chmod file: %v", err)
 	}
 
@@ -199,8 +199,8 @@ func TestAccAppendResource(t *testing.T) {
 							return fmt.Errorf("expected file size %d, got %d", len("hello world"), hdr.Size)
 						}
 						// ensure the mode is preserved
-						if hdr.Mode != 0755 {
-							return fmt.Errorf("expected mode %d, got %d", 0755, hdr.Mode)
+						if hdr.Mode != 0o755 {
+							return fmt.Errorf("expected mode %d, got %d", 0o755, hdr.Mode)
 						}
 
 						// check the actual file contents are what we expect

--- a/internal/provider/exec_test_data_source.go
+++ b/internal/provider/exec_test_data_source.go
@@ -238,8 +238,10 @@ func (positiveIntValidator) ValidateInt64(ctx context.Context, req validator.Int
 	}
 }
 
-var mu sync.Mutex
-var freePorts = map[int]bool{}
+var (
+	mu        sync.Mutex
+	freePorts = map[int]bool{}
+)
 
 func freePort() (int, error) {
 	mu.Lock()

--- a/internal/provider/structure_test_data_source.go
+++ b/internal/provider/structure_test_data_source.go
@@ -55,6 +55,7 @@ type StructureTestDataSourceModel struct {
 		Permissions []struct {
 			Block    types.String `tfsdk:"block"` // Expected to be a string representation of os.FileMode
 			Override types.List   `tfsdk:"override"`
+			Path     types.String `tfsdk:"path"`
 		} `tfsdk:"permissions"`
 	} `tfsdk:"conditions"`
 
@@ -117,6 +118,7 @@ func (d *StructureTestDataSource) Schema(ctx context.Context, req datasource.Sch
 									"override": basetypes.ListType{
 										ElemType: basetypes.StringType{},
 									},
+									"path": basetypes.StringType{},
 								},
 							},
 						},
@@ -251,8 +253,15 @@ func (d *StructureTestDataSource) Read(ctx context.Context, req datasource.ReadR
 				resp.Diagnostics.Append(diags...)
 				return
 			}
+
+			var path string
+			if p.Path.IsNull() || p.Path.IsUnknown() {
+				path = "."
+			} else {
+				path = p.Path.ValueString()
+			}
 			conds = append(conds, structure.PermissionsCondition{Want: map[string]structure.Permission{
-				".": {
+				path: {
 					Block:    m,
 					Override: overrideStrings,
 				},

--- a/internal/provider/structure_test_data_source.go
+++ b/internal/provider/structure_test_data_source.go
@@ -36,15 +36,26 @@ type StructureTestDataSource struct {
 type StructureTestDataSourceModel struct {
 	Digest     types.String `tfsdk:"digest"`
 	Conditions []struct {
+		Dirs []struct {
+			FilesOnly types.Bool   `tfsdk:"files_only"`
+			Mode      types.String `tfsdk:"mode"` // Expected to be a string representation of os.FileMode
+			Path      types.String `tfsdk:"path"`
+			Recursive types.Bool   `tfsdk:"recursive"`
+		} `tfsdk:"dirs"`
 		Env []struct {
 			Key   types.String `tfsdk:"key"`
 			Value types.String `tfsdk:"value"`
 		} `tfsdk:"env"`
 		Files []struct {
-			Path  types.String `tfsdk:"path"`
-			Regex types.String `tfsdk:"regex"`
-			Mode  types.String `tfsdk:"mode"` // Expected to be a string representation of os.FileMode
+			Mode     types.String `tfsdk:"mode"` // Expected to be a string representation of os.FileMode
+			Optional types.Bool   `tfsdk:"optional"`
+			Path     types.String `tfsdk:"path"`
+			Regex    types.String `tfsdk:"regex"`
 		} `tfsdk:"files"`
+		Permissions []struct {
+			Block    types.String `tfsdk:"block"` // Expected to be a string representation of os.FileMode
+			Override types.List   `tfsdk:"override"`
+		} `tfsdk:"permissions"`
 	} `tfsdk:"conditions"`
 
 	Id        types.String `tfsdk:"id"`
@@ -71,6 +82,16 @@ func (d *StructureTestDataSource) Schema(ctx context.Context, req datasource.Sch
 				Required:            true,
 				ElementType: basetypes.ObjectType{
 					AttrTypes: map[string]attr.Type{
+						"dirs": basetypes.ListType{
+							ElemType: basetypes.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"files_only": basetypes.BoolType{},
+									"mode":       basetypes.StringType{}, // Expected to be a string representation of os.FileMode
+									"path":       basetypes.StringType{},
+									"recursive":  basetypes.BoolType{},
+								},
+							},
+						},
 						"env": basetypes.ListType{
 							ElemType: basetypes.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -82,9 +103,20 @@ func (d *StructureTestDataSource) Schema(ctx context.Context, req datasource.Sch
 						"files": basetypes.ListType{
 							ElemType: basetypes.ObjectType{
 								AttrTypes: map[string]attr.Type{
-									"path":  basetypes.StringType{},
-									"regex": basetypes.StringType{},
-									"mode":  basetypes.StringType{}, // Expected to be a string representation of os.FileMode
+									"mode":     basetypes.StringType{}, // Expected to be a string representation of os.FileMode
+									"optional": basetypes.BoolType{},
+									"path":     basetypes.StringType{},
+									"regex":    basetypes.StringType{},
+								},
+							},
+						},
+						"permissions": basetypes.ListType{
+							ElemType: basetypes.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"block": basetypes.StringType{}, // Expected to be a string representation of os.FileMode
+									"override": basetypes.ListType{
+										ElemType: basetypes.StringType{},
+									},
 								},
 							},
 						},
@@ -124,12 +156,23 @@ func parseFileMode(modeStr string) (*os.FileMode, error) {
 	if modeStr == "" {
 		return nil, nil
 	}
-	mode, err := strconv.ParseInt(modeStr, 8, 32)
+	mode, err := strconv.ParseUint(modeStr, 8, 32)
 	if err != nil {
 		return nil, fmt.Errorf("parsing file mode %q: %w", modeStr, err)
 	}
-	umode := uint32(mode)
-	m := os.FileMode(umode) // Convert to os.FileMode
+
+	m := os.FileMode(uint32(mode) & 0o777)
+
+	if mode&0o4000 != 0 {
+		m |= os.ModeSetuid
+	}
+	if mode&0o2000 != 0 {
+		m |= os.ModeSetgid
+	}
+	if mode&0o1000 != 0 {
+		m |= os.ModeSticky
+	}
+
 	return &m, nil
 }
 
@@ -154,6 +197,27 @@ func (d *StructureTestDataSource) Read(ctx context.Context, req datasource.ReadR
 
 	var conds structure.Conditions
 	for _, c := range data.Conditions {
+
+		for _, d := range c.Dirs {
+			if d.FilesOnly.ValueBool() && !d.Recursive.ValueBool() {
+				resp.Diagnostics.AddError("Invalid input", "Can only use files_only with recursive")
+				return
+			}
+
+			m, err := parseFileMode(d.Mode.ValueString())
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid file mode", fmt.Sprintf("Unable to parse file mode %q, got error: %s", d.Mode.ValueString(), err))
+				return
+			}
+			conds = append(conds, structure.DirsCondition{Want: map[string]structure.Dir{
+				d.Path.ValueString(): {
+					FilesOnly: d.FilesOnly.ValueBool(),
+					Mode:      m,
+					Recursive: d.Recursive.ValueBool(),
+				},
+			}})
+		}
+
 		for _, e := range c.Env {
 			conds = append(conds, structure.EnvCondition{Want: map[string]string{
 				e.Key.ValueString(): e.Value.ValueString(),
@@ -168,8 +232,29 @@ func (d *StructureTestDataSource) Read(ctx context.Context, req datasource.ReadR
 			}
 			conds = append(conds, structure.FilesCondition{Want: map[string]structure.File{
 				f.Path.ValueString(): {
-					Regex: f.Regex.ValueString(),
-					Mode:  m,
+					Mode:     m,
+					Optional: f.Optional.ValueBool(),
+					Regex:    f.Regex.ValueString(),
+				},
+			}})
+		}
+
+		for _, p := range c.Permissions {
+			m, err := parseFileMode(p.Block.ValueString())
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid file mode", fmt.Sprintf("Unable to parse file mode %q, got error: %s", p.Block.ValueString(), err))
+				return
+			}
+			var overrideStrings []string
+			diags := p.Override.ElementsAs(ctx, &overrideStrings, false)
+			if diags.HasError() {
+				resp.Diagnostics.Append(diags...)
+				return
+			}
+			conds = append(conds, structure.PermissionsCondition{Want: map[string]structure.Permission{
+				".": {
+					Block:    m,
+					Override: overrideStrings,
 				},
 			}})
 		}

--- a/internal/provider/tag_resource.go
+++ b/internal/provider/tag_resource.go
@@ -16,8 +16,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ resource.Resource = &TagResource{}
-var _ resource.ResourceWithImportState = &TagResource{}
+var (
+	_ resource.Resource                = &TagResource{}
+	_ resource.ResourceWithImportState = &TagResource{}
+)
 
 func NewTagResource() resource.Resource {
 	return &TagResource{}

--- a/internal/provider/tags_resource.go
+++ b/internal/provider/tags_resource.go
@@ -20,8 +20,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-var _ resource.Resource = &TagsResource{}
-var _ resource.ResourceWithImportState = &TagsResource{}
+var (
+	_ resource.Resource                = &TagsResource{}
+	_ resource.ResourceWithImportState = &TagsResource{}
+)
 
 func NewTagsResource() resource.Resource {
 	return &TagsResource{}

--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ func main() {
 		Address: "registry.terraform.io/chainguard-dev/oci",
 		Debug:   debug,
 	})
-
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/pkg/structure/structure.go
+++ b/pkg/structure/structure.go
@@ -303,8 +303,11 @@ func (p PermissionsCondition) Check(i v1.Image) error {
 
 	var errs []error
 
-	for _, perm := range p.Want {
-		err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+	for path, perm := range p.Want {
+		// https://pkg.go.dev/io/fs#ValidPath
+		name := strings.TrimPrefix(path, "/")
+
+		err := fs.WalkDir(fsys, name, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Currently, structure tests allow for specific file permission checks; while this works for files that are guaranteed to exist, there are other files and paths that may not exist universally but may also be too numerous to check for on a per-module caller basis.

This PR addresses this gap by allowing for files to be classified as optional. If a structure test encounters an optional file that does not exist, that file will be ignored instead of throwing an error (this behavior is opt-in, as well).

There are also cases where we care about more than one file in a directory (and maybe a specific directory?). To address this, the PR adds support for top-level directory permission checks as well recursive checks to ensure that every path within a given directory has the expected permission. For the latter, there is also an opt-in input to limit the check to files within the given directory.

There's also a possibility that we want to fail a test if any paths with a certain permission are discovered which is supported via a new `permissions` block. Overrides can also be specified for this check if there are documented exceptions.