### PR TITLE
Ignore symlinks within directory and permission tests

### DIFF
--- a/pkg/structure/structure.go
+++ b/pkg/structure/structure.go
@@ -231,6 +231,11 @@ func (d DirsCondition) Check(i v1.Image) error {
 					return err
 				}
 
+				// ignore symlinks which will register as 777
+				if d.Type()&fs.ModeSymlink == fs.ModeSymlink {
+					return nil
+				}
+
 				if dir.FilesOnly && d.IsDir() {
 					return nil
 				}
@@ -310,6 +315,11 @@ func (p PermissionsCondition) Check(i v1.Image) error {
 		err := fs.WalkDir(fsys, name, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
+			}
+
+			// ignore symlinks which will register as 777
+			if d.Type()&fs.ModeSymlink == fs.ModeSymlink {
+				return nil
 			}
 
 			fi, err := d.Info()


### PR DESCRIPTION
Symlinks will always display as `777` files, so we can ignore them by default when running recursive tests. If we care about a specific symlink permission, we can use a `file` check similar to what our test does.