### PR TITLE
Add oci_layout_path option to oci_structure_test

### DIFF
--- a/docs/data-sources/structure_test.md
+++ b/docs/data-sources/structure_test.md
@@ -20,6 +20,10 @@ Structure test data source
 - `conditions` (List of Object) List of conditions to test (see [below for nested schema](#nestedatt--conditions))
 - `digest` (String) Image digest to test
 
+### Optional
+
+- `oci_layout_path` (String) Optional filesystem path to a local OCI image layout. When set, the test reads the image from this layout instead of pulling the digest from the registry.
+
 ### Read-Only
 
 - `id` (String) Fully qualified image digest of the image.

--- a/internal/provider/structure_test_data_source.go
+++ b/internal/provider/structure_test_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chainguard-dev/terraform-provider-oci/pkg/validators"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -34,8 +35,9 @@ type StructureTestDataSource struct {
 
 // StructureTestDataSourceModel describes the data source data model.
 type StructureTestDataSourceModel struct {
-	Digest     types.String `tfsdk:"digest"`
-	Conditions []struct {
+	Digest        types.String `tfsdk:"digest"`
+	OciLayoutPath types.String `tfsdk:"oci_layout_path"`
+	Conditions    []struct {
 		Dirs []struct {
 			FilesOnly types.Bool   `tfsdk:"files_only"`
 			Mode      types.String `tfsdk:"mode"` // Expected to be a string representation of os.FileMode
@@ -77,6 +79,10 @@ func (d *StructureTestDataSource) Schema(ctx context.Context, req datasource.Sch
 				Optional:            false,
 				Required:            true,
 				Validators:          []validator.String{validators.DigestValidator{}},
+			},
+			"oci_layout_path": schema.StringAttribute{
+				MarkdownDescription: "Optional filesystem path to a local OCI image layout. When set, the test reads the image from this layout instead of pulling the digest from the registry.",
+				Optional:            true,
 			},
 			"conditions": schema.ListAttribute{
 				MarkdownDescription: "List of conditions to test",
@@ -154,6 +160,28 @@ func (d *StructureTestDataSource) Configure(ctx context.Context, req datasource.
 	d.popts = *popts
 }
 
+// imageFromLayout reads an OCI image layout from the given path and returns
+// the first image in its index. Mirrors the Manifests[0] selection used for
+// remote indexes above.
+func imageFromLayout(path string) (v1.Image, error) {
+	p, err := layout.FromPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening layout: %w", err)
+	}
+	idx, err := p.ImageIndex()
+	if err != nil {
+		return nil, fmt.Errorf("reading layout index: %w", err)
+	}
+	im, err := idx.IndexManifest()
+	if err != nil {
+		return nil, fmt.Errorf("reading index manifest: %w", err)
+	}
+	if len(im.Manifests) == 0 {
+		return nil, fmt.Errorf("layout index is empty")
+	}
+	return idx.Image(im.Manifests[0].Digest)
+}
+
 func parseFileMode(modeStr string) (*os.FileMode, error) {
 	if modeStr == "" {
 		return nil, nil
@@ -191,10 +219,15 @@ func (d *StructureTestDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
-	desc, err := remote.Get(ref, d.popts.withContext(ctx)...)
-	if err != nil {
-		resp.Diagnostics.AddError("Unable to fetch image", fmt.Sprintf("Unable to fetch image for ref %s, got error: %s", data.Digest.ValueString(), err))
-		return
+	useLayout := !data.OciLayoutPath.IsNull() && data.OciLayoutPath.ValueString() != ""
+
+	var desc *remote.Descriptor
+	if !useLayout {
+		desc, err = remote.Get(ref, d.popts.withContext(ctx)...)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to fetch image", fmt.Sprintf("Unable to fetch image for ref %s, got error: %s", data.Digest.ValueString(), err))
+			return
+		}
 	}
 
 	var conds structure.Conditions
@@ -271,6 +304,12 @@ func (d *StructureTestDataSource) Read(ctx context.Context, req datasource.ReadR
 
 	var img v1.Image
 	switch {
+	case useLayout:
+		img, err = imageFromLayout(data.OciLayoutPath.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to read image from layout", fmt.Sprintf("Unable to read image from layout %s, got error: %s", data.OciLayoutPath.ValueString(), err))
+			return
+		}
 	case desc.MediaType.IsImage():
 		img, err = desc.Image()
 		if err != nil {

--- a/internal/provider/structure_test_data_source_test.go
+++ b/internal/provider/structure_test_data_source_test.go
@@ -12,6 +12,7 @@ import (
 	ocitesting "github.com/chainguard-dev/terraform-provider-oci/testing"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -373,6 +374,111 @@ func TestInvalidPathEnv(t *testing.T) {
 		}
 	}`, ref),
 			ExpectError: regexp.MustCompile(`env "PATH" value "\$PATH" references relative path or literal \$ string "\$PATH"\nenv "LUA_PATH" value "baz;/whatever;\$LUA_PATH" references relative path or\nliteral \$ string "baz"\nenv "LUA_PATH" value "baz;/whatever;\$LUA_PATH" references relative path or\nliteral \$ string "\$LUA_PATH"`),
+		}},
+	})
+}
+
+// buildLayoutTestImage returns a single-arch image index containing one image
+// with a known file and env, suitable for asserting structure_test conditions.
+func buildLayoutTestImage(t *testing.T) v1.ImageIndex {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	_ = tw.WriteHeader(&tar.Header{Name: "foo", Mode: 0o644, Size: 3})
+	_, _ = tw.Write([]byte("bar"))
+	tw.Close()
+
+	l, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewBuffer(buf.Bytes())), nil
+	})
+	if err != nil {
+		t.Fatalf("layer: %v", err)
+	}
+	img, err := mutate.AppendLayers(empty.Image, l)
+	if err != nil {
+		t.Fatalf("append layers: %v", err)
+	}
+	img, err = mutate.Config(img, v1.Config{Env: []string{"FOO=bar"}})
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	return mutate.AppendManifests(empty.Index, mutate.IndexAddendum{Add: img})
+}
+
+// TestAccStructureTestDataSource_Layout verifies that when layout_path is set
+// the data source reads from the local OCI layout and never touches the
+// registry referenced by digest. The digest points at an unreachable host —
+// any accidental remote.Get would fail loudly.
+func TestAccStructureTestDataSource_Layout(t *testing.T) {
+	idx := buildLayoutTestImage(t)
+	dir := t.TempDir()
+	if _, err := layout.Write(dir, idx); err != nil {
+		t.Fatalf("layout.Write: %v", err)
+	}
+	d, err := idx.Digest()
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	ref := fmt.Sprintf("does-not-exist.invalid/test@%s", d.String())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: fmt.Sprintf(`data "oci_structure_test" "test" {
+  digest      = %q
+  oci_layout_path = %q
+
+  conditions {
+    env {
+      key   = "FOO"
+      value = "bar"
+    }
+    files {
+      path  = "/foo"
+      regex = "bar"
+      mode  = "0644"
+    }
+  }
+}`, ref, dir),
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("data.oci_structure_test.test", "tested_ref", ref),
+				resource.TestCheckResourceAttr("data.oci_structure_test.test", "id", ref),
+			),
+		}},
+	})
+}
+
+// TestAccStructureTestDataSource_LayoutFailingCondition asserts that a layout
+// read with a condition the image does not satisfy yields the same
+// "does not match rules" diagnostic shape as the remote-pull path.
+func TestAccStructureTestDataSource_LayoutFailingCondition(t *testing.T) {
+	idx := buildLayoutTestImage(t)
+	dir := t.TempDir()
+	if _, err := layout.Write(dir, idx); err != nil {
+		t.Fatalf("layout.Write: %v", err)
+	}
+	d, err := idx.Digest()
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	ref := fmt.Sprintf("does-not-exist.invalid/test@%s", d.String())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: fmt.Sprintf(`data "oci_structure_test" "test" {
+  digest      = %q
+  oci_layout_path = %q
+
+  conditions {
+    files {
+      path = "/not-there"
+    }
+  }
+}`, ref, dir),
+			ExpectError: regexp.MustCompile(`does not match rules`),
 		}},
 	})
 }


### PR DESCRIPTION
When layout_path is set, the data source reads the image from a local OCI image layout instead of pulling the digest from the registry. The in-memory Conditions.Check is unchanged; only the v1.Image source differs. This pairs with the new oci_layout_path attribute on apko_build to let publisher tests run against the image we just built locally instead of round-tripping through the registry. When layout_path is unset the behavior is identical to before, so existing callers are unaffected.
