### PR TITLE
Bump Go to 1.27.0 and golangci-lint to v2.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,4 +222,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12
+          version: v2.13

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainguard-dev/terraform-provider-oci
 
-go 1.26.4
+go 1.27.0
 
 require (
 	github.com/google/go-containerregistry v0.22.0


### PR DESCRIPTION
golangci-lint v2.12 predates Go 1.27 and cannot lint a module declaring it, so the CI action version moves to v2.13 which is built with Go 1.27. The new toolchain and linter report no new issues.
