### PR TITLE
Add files_only flag to structure test permissions block

### DIFF
--- a/docs/data-sources/structure_test.md
+++ b/docs/data-sources/structure_test.md
@@ -76,5 +76,6 @@ Required:
 Required:
 
 - `block` (String)
+- `files_only` (Boolean)
 - `override` (List of String)
 - `path` (String)

--- a/internal/provider/structure_test_data_source.go
+++ b/internal/provider/structure_test_data_source.go
@@ -55,9 +55,10 @@ type StructureTestDataSourceModel struct {
 			Regex    types.String `tfsdk:"regex"`
 		} `tfsdk:"files"`
 		Permissions []struct {
-			Block    types.String `tfsdk:"block"` // Expected to be a string representation of os.FileMode
-			Override types.List   `tfsdk:"override"`
-			Path     types.String `tfsdk:"path"`
+			Block     types.String `tfsdk:"block"` // Expected to be a string representation of os.FileMode
+			FilesOnly types.Bool   `tfsdk:"files_only"`
+			Override  types.List   `tfsdk:"override"`
+			Path      types.String `tfsdk:"path"`
 		} `tfsdk:"permissions"`
 	} `tfsdk:"conditions"`
 
@@ -120,7 +121,8 @@ func (d *StructureTestDataSource) Schema(ctx context.Context, req datasource.Sch
 						"permissions": basetypes.ListType{
 							ElemType: basetypes.ObjectType{
 								AttrTypes: map[string]attr.Type{
-									"block": basetypes.StringType{}, // Expected to be a string representation of os.FileMode
+									"block":      basetypes.StringType{}, // Expected to be a string representation of os.FileMode
+									"files_only": basetypes.BoolType{},
 									"override": basetypes.ListType{
 										ElemType: basetypes.StringType{},
 									},
@@ -295,8 +297,9 @@ func (d *StructureTestDataSource) Read(ctx context.Context, req datasource.ReadR
 			}
 			conds = append(conds, structure.PermissionsCondition{Want: map[string]structure.Permission{
 				path: {
-					Block:    m,
-					Override: overrideStrings,
+					Block:     m,
+					Override:  overrideStrings,
+					FilesOnly: p.FilesOnly.ValueBool(),
 				},
 			}})
 		}

--- a/internal/provider/structure_test_data_source_test.go
+++ b/internal/provider/structure_test_data_source_test.go
@@ -272,12 +272,36 @@ func TestAccStructureTestDataSource(t *testing.T) {
     permissions {
       block = "0666"
     }
+    permissions {
+      path = "/files_only/foo"
+      block = "0777"
+      files_only = true
+    }
   }
 }`, ref),
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("data.oci_structure_test.test", "digest", ref.String()),
 				resource.TestCheckResourceAttr("data.oci_structure_test.test", "id", ref.String()),
 			),
+		}},
+	})
+
+	// Without files_only, 0777 directories are matched by the blocked permission.
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: fmt.Sprintf(`data "oci_structure_test" "test" {
+  digest = %q
+
+  conditions {
+    permissions {
+      path = "/files_only/foo"
+      block = "0777"
+    }
+  }
+}`, ref),
+			ExpectError: regexp.MustCompile(`file "files_only/foo" mode matches blocked permission 777.*\n.*file "files_only/foo/bar" mode matches blocked permission 777`),
 		}},
 	})
 

--- a/pkg/structure/structure.go
+++ b/pkg/structure/structure.go
@@ -286,8 +286,9 @@ type PermissionsCondition struct {
 }
 
 type Permission struct {
-	Block    *os.FileMode
-	Override []string
+	Block     *os.FileMode
+	Override  []string
+	FilesOnly bool // only check regular files, skipping directories
 }
 
 func (p PermissionsCondition) Check(_ v1.Image, fsys *tarfs.FS) error {
@@ -304,6 +305,10 @@ func (p PermissionsCondition) Check(_ v1.Image, fsys *tarfs.FS) error {
 
 			// ignore symlinks which will register as 777
 			if d.Type()&fs.ModeSymlink == fs.ModeSymlink {
+				return nil
+			}
+
+			if perm.FilesOnly && d.IsDir() {
 				return nil
 			}
 


### PR DESCRIPTION
The permissions condition walks every entry under the path and compares its mode against the blocked value, directories included. Images commonly ship world-writable directories such as cache or data volumes while still needing to reject world-writable files, and the current condition cannot express that without enumerating every such directory in override. Setting files_only skips directories, mirroring the existing flag on the dirs block. The flag is opt-in, so existing configurations behave exactly as before.
