### PR TITLE
Index image filesystem in memory instead of via a temp file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/jonjohnsonjr/targz v0.0.0-20241113200849-4986e08f3fb4
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,6 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
-github.com/jonjohnsonjr/targz v0.0.0-20241113200849-4986e08f3fb4 h1:yzUKZR6eq4hfKkNLe2KfxOBiVHyjXny7g4bEDuiYCtY=
-github.com/jonjohnsonjr/targz v0.0.0-20241113200849-4986e08f3fb4/go.mod h1:vFsMbFCBsTclpEtIkbCOBAJj1mBsqoMtm22ibo1cG2o=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=

--- a/pkg/structure/structure.go
+++ b/pkg/structure/structure.go
@@ -44,15 +44,13 @@ func layerStream(i v1.Image) (io.ReadCloser, error) {
 // of it, capturing the contents of the given paths. Nothing is written to disk.
 // It retries on errors like unexpected EOF.
 func indexImage(i v1.Image, capture map[string]bool) (*tarIndex, error) {
-	reopen := func() (io.ReadCloser, error) { return layerStream(i) }
-
 	var lastErr error
 	for attempt := range maxRetries {
 		if attempt > 0 {
 			time.Sleep(retryBackoff * time.Duration(attempt))
 		}
 
-		idx, err := tryIndexImage(reopen, capture)
+		idx, err := tryIndexImage(i, capture)
 		if err == nil {
 			return idx, nil
 		}
@@ -62,14 +60,14 @@ func indexImage(i v1.Image, capture map[string]bool) (*tarIndex, error) {
 	return nil, fmt.Errorf("after %d attempts: %w", maxRetries, lastErr)
 }
 
-func tryIndexImage(reopen func() (io.ReadCloser, error), capture map[string]bool) (*tarIndex, error) {
-	rc, err := reopen()
+func tryIndexImage(i v1.Image, capture map[string]bool) (*tarIndex, error) {
+	rc, err := layerStream(i)
 	if err != nil {
 		return nil, err
 	}
 	defer rc.Close()
 
-	idx, err := newTarIndex(rc, capture, reopen)
+	idx, err := newTarIndex(rc, capture)
 	if err != nil {
 		return nil, fmt.Errorf("indexing image filesystem: %w", err)
 	}

--- a/pkg/structure/structure.go
+++ b/pkg/structure/structure.go
@@ -12,7 +12,6 @@ import (
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
-	"github.com/jonjohnsonjr/targz/tarfs"
 )
 
 // mask out file type bits for permission comparisons (e.g., ignore directory and symlink bits).
@@ -23,89 +22,95 @@ const (
 	retryBackoff = 1 * time.Second
 )
 
-// extractLayersToTarFS extracts the image layers to a temporary file and returns a tarfs.
+// layerStream returns a reader over the flattened, uncompressed filesystem of
+// the image. Single-layer images are streamed directly. Multi-layer images go
+// through mutate.Extract, which applies whiteouts.
+func layerStream(i v1.Image) (io.ReadCloser, error) {
+	ls, err := i.Layers()
+	if err != nil {
+		return nil, fmt.Errorf("getting image layers: %w", err)
+	}
+	if len(ls) == 1 {
+		rc, err := ls[0].Uncompressed()
+		if err != nil {
+			return nil, fmt.Errorf("getting uncompressed layer: %w", err)
+		}
+		return rc, nil
+	}
+	return mutate.Extract(i), nil
+}
+
+// indexImage streams the image filesystem once and builds an in-memory index
+// of it, capturing the contents of the given paths. Nothing is written to disk.
 // It retries on errors like unexpected EOF.
-func extractLayersToTarFS(i v1.Image) (*tarfs.FS, func(), error) {
+func indexImage(i v1.Image, capture map[string]bool) (*tarIndex, error) {
+	reopen := func() (io.ReadCloser, error) { return layerStream(i) }
+
 	var lastErr error
 	for attempt := range maxRetries {
 		if attempt > 0 {
 			time.Sleep(retryBackoff * time.Duration(attempt))
 		}
 
-		fsys, cleanup, err := tryExtractLayers(i)
+		idx, err := tryIndexImage(reopen, capture)
 		if err == nil {
-			return fsys, cleanup, nil
+			return idx, nil
 		}
 		lastErr = err
 	}
 
-	return nil, nil, fmt.Errorf("after %d attempts: %w", maxRetries, lastErr)
+	return nil, fmt.Errorf("after %d attempts: %w", maxRetries, lastErr)
 }
 
-func tryExtractLayers(i v1.Image) (*tarfs.FS, func(), error) {
-	ls, err := i.Layers()
+func tryIndexImage(reopen func() (io.ReadCloser, error), capture map[string]bool) (*tarIndex, error) {
+	rc, err := reopen()
 	if err != nil {
-		return nil, nil, fmt.Errorf("getting image layers: %w", err)
-	}
-
-	var rc io.ReadCloser
-	// If there's only one layer, we don't need to extract it.
-	if len(ls) == 1 {
-		rc, err = ls[0].Uncompressed()
-		if err != nil {
-			return nil, nil, fmt.Errorf("getting uncompressed layer: %w", err)
-		}
-	} else {
-		rc = mutate.Extract(i)
+		return nil, err
 	}
 	defer rc.Close()
 
-	tmp, err := os.CreateTemp("", "structure-test")
+	idx, err := newTarIndex(rc, capture, reopen)
 	if err != nil {
-		return nil, nil, fmt.Errorf("creating temp file: %w", err)
+		return nil, fmt.Errorf("indexing image filesystem: %w", err)
 	}
-	cleanup := func() { os.Remove(tmp.Name()) }
-
-	size, err := io.Copy(tmp, rc)
-	if err != nil {
-		cleanup()
-		return nil, nil, fmt.Errorf("copying layer to temp file: %w", err)
-	}
-
-	fsys, err := tarfs.New(tmp, size)
-	if err != nil {
-		cleanup()
-		return nil, nil, fmt.Errorf("parsing tar filesystem: %w", err)
-	}
-
-	return fsys, cleanup, nil
+	return idx, nil
 }
 
 type Condition interface {
-	Check(v1.Image, *tarfs.FS) error
+	Check(v1.Image, fs.FS) error
+}
+
+// contentCondition is implemented by conditions that need to read file
+// contents, so the contents can be captured while the image is indexed.
+type contentCondition interface {
+	ContentPaths() []string
 }
 
 type Conditions []Condition
 
 func (c Conditions) Check(i v1.Image) error {
-	// Check if any condition needs the filesystem
+	// Check if any condition needs the filesystem, and which file contents
+	// have to be captured while indexing it.
 	needsFS := false
+	capture := map[string]bool{}
 	for _, cond := range c {
 		if _, ok := cond.(EnvCondition); !ok {
 			needsFS = true
-			break
+		}
+		if cc, ok := cond.(contentCondition); ok {
+			for _, p := range cc.ContentPaths() {
+				capture[normalize(p)] = true
+			}
 		}
 	}
 
-	var fsys *tarfs.FS
+	var fsys fs.FS
 	if needsFS {
-		var cleanup func()
-		var err error
-		fsys, cleanup, err = extractLayersToTarFS(i)
+		idx, err := indexImage(i, capture)
 		if err != nil {
 			return fmt.Errorf("extracting layers: %w", err)
 		}
-		defer cleanup()
+		fsys = idx
 	}
 
 	var errs []error
@@ -119,7 +124,7 @@ type EnvCondition struct {
 	Want map[string]string
 }
 
-func (e EnvCondition) Check(i v1.Image, _ *tarfs.FS) error {
+func (e EnvCondition) Check(i v1.Image, _ fs.FS) error {
 	cf, err := i.ConfigFile()
 	if err != nil {
 		return fmt.Errorf("getting image config: %w", err)
@@ -160,7 +165,18 @@ type File struct {
 	Regex    string
 }
 
-func (f FilesCondition) Check(_ v1.Image, fsys *tarfs.FS) error {
+// ContentPaths returns the files whose contents are matched against a regex.
+func (f FilesCondition) ContentPaths() []string {
+	var paths []string
+	for p, f := range f.Want {
+		if f.Regex != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+func (f FilesCondition) Check(_ v1.Image, fsys fs.FS) error {
 	var errs []error
 
 	for path, f := range f.Want {
@@ -224,7 +240,7 @@ type Dir struct {
 	Recursive bool
 }
 
-func (d DirsCondition) Check(_ v1.Image, fsys *tarfs.FS) error {
+func (d DirsCondition) Check(_ v1.Image, fsys fs.FS) error {
 	var errs []error
 
 	for path, dir := range d.Want {
@@ -232,7 +248,7 @@ func (d DirsCondition) Check(_ v1.Image, fsys *tarfs.FS) error {
 		name := strings.TrimPrefix(path, "/")
 
 		if !dir.Recursive {
-			fi, err := fsys.Stat(name)
+			fi, err := fs.Stat(fsys, name)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("statting directory %q: %w", path, err))
 			}
@@ -291,7 +307,7 @@ type Permission struct {
 	FilesOnly bool // only check regular files, skipping directories
 }
 
-func (p PermissionsCondition) Check(_ v1.Image, fsys *tarfs.FS) error {
+func (p PermissionsCondition) Check(_ v1.Image, fsys fs.FS) error {
 	var errs []error
 
 	for path, perm := range p.Want {

--- a/pkg/structure/tarindex.go
+++ b/pkg/structure/tarindex.go
@@ -1,0 +1,242 @@
+package structure
+
+import (
+	"archive/tar"
+	"bytes"
+	"cmp"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"slices"
+	"strings"
+	"time"
+)
+
+// tarIndex is an in-memory view of a tar stream. It records the header of every
+// entry so that metadata questions (existence, mode, type, directory listings)
+// can be answered without keeping the tar around, and it captures the contents
+// of a chosen set of paths during the single pass over the stream. Contents of
+// any other regular file can still be read on demand, at the cost of streaming
+// the tar a second time via reopen.
+type tarIndex struct {
+	entries map[string]*tarEntry
+	dirs    map[string][]fs.DirEntry
+
+	// reopen returns a fresh reader over the same tar stream. It is only used
+	// when a caller opens a regular file whose contents were not captured.
+	reopen func() (io.ReadCloser, error)
+}
+
+type tarEntry struct {
+	hdr  tar.Header
+	name string // normalized path within the tar
+	dir  string // path.Dir(name)
+	fi   fs.FileInfo
+
+	captured bool
+	data     []byte
+}
+
+func (e *tarEntry) Name() string               { return e.fi.Name() }
+func (e *tarEntry) IsDir() bool                { return e.fi.IsDir() }
+func (e *tarEntry) Type() fs.FileMode          { return e.fi.Mode().Type() }
+func (e *tarEntry) Info() (fs.FileInfo, error) { return e.fi, nil }
+
+// newTarIndex consumes r to completion, indexing every header. Contents are
+// retained for entries whose normalized path is in capture.
+func newTarIndex(r io.Reader, capture map[string]bool, reopen func() (io.ReadCloser, error)) (*tarIndex, error) {
+	idx := &tarIndex{
+		entries: map[string]*tarEntry{},
+		dirs:    map[string][]fs.DirEntry{},
+		reopen:  reopen,
+	}
+
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		name := normalize(hdr.Name)
+		e := &tarEntry{
+			hdr:  *hdr,
+			name: name,
+			dir:  path.Dir(name),
+			fi:   hdr.FileInfo(),
+		}
+
+		if capture[name] && hdr.Typeflag == tar.TypeReg {
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, fmt.Errorf("reading %q: %w", name, err)
+			}
+			e.captured = true
+			e.data = data
+		}
+
+		idx.entries[name] = e
+		idx.dirs[e.dir] = append(idx.dirs[e.dir], e)
+	}
+
+	for _, children := range idx.dirs {
+		slices.SortFunc(children, func(a, b fs.DirEntry) int {
+			return cmp.Compare(a.Name(), b.Name())
+		})
+	}
+
+	return idx, nil
+}
+
+// normalize strips a leading "/" or "./" and a trailing "/" so that paths from
+// tar headers and from callers compare equal.
+func normalize(s string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(strings.TrimSuffix(s, "/"), "/"), "./")
+}
+
+type rootInfo struct{}
+
+func (rootInfo) Name() string       { return "." }
+func (rootInfo) Size() int64        { return 0 }
+func (rootInfo) Mode() fs.FileMode  { return fs.ModeDir }
+func (rootInfo) ModTime() time.Time { return time.Unix(0, 0) }
+func (rootInfo) IsDir() bool        { return true }
+func (rootInfo) Sys() any           { return nil }
+
+// Stat implements fs.StatFS. It does not follow symlinks.
+func (idx *tarIndex) Stat(name string) (fs.FileInfo, error) {
+	if e, ok := idx.entries[name]; ok {
+		return e.fi, nil
+	}
+	// fs.WalkDir expects "." to return a root entry to bootstrap the walk.
+	if name == "." {
+		return rootInfo{}, nil
+	}
+	return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
+}
+
+// ReadDir implements fs.ReadDirFS. Directories that only exist implicitly, as
+// the parent of some entry, still list their children.
+func (idx *tarIndex) ReadDir(name string) ([]fs.DirEntry, error) {
+	children, ok := idx.dirs[name]
+	if !ok {
+		return []fs.DirEntry{}, nil
+	}
+	return children, nil
+}
+
+// Arbitrary limit borrowed from filepath.EvalSymlinks.
+const maxHops = 255
+
+// Open implements fs.FS, following symlinks and hard links.
+func (idx *tarIndex) Open(name string) (fs.File, error) {
+	if name == "." {
+		return &tarFile{fi: rootInfo{}, r: bytes.NewReader(nil)}, nil
+	}
+	return idx.open(name, 0)
+}
+
+func (idx *tarIndex) open(name string, hops int) (fs.File, error) {
+	if hops > maxHops {
+		return nil, fmt.Errorf("opening %s: chased too many (%d) symlinks", name, maxHops)
+	}
+
+	e, ok := idx.entries[name]
+	if !ok {
+		// Deal with symlinked parent directories.
+		for dir := range parentDirs(name) {
+			p, ok := idx.entries[dir]
+			if !ok || p.hdr.Typeflag != tar.TypeSymlink {
+				continue
+			}
+
+			rest := strings.TrimPrefix(name, dir)
+			link := p.hdr.Linkname
+			if path.IsAbs(link) {
+				return idx.open(normalize(path.Join(link, rest)), hops+1)
+			}
+			return idx.open(path.Join(p.dir, link, rest), hops+1)
+		}
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+
+	switch e.hdr.Typeflag {
+	case tar.TypeSymlink, tar.TypeLink:
+		link := e.hdr.Linkname
+		if path.IsAbs(link) || e.hdr.Typeflag == tar.TypeLink {
+			return idx.open(normalize(link), hops+1)
+		}
+		return idx.open(path.Join(e.dir, link), hops+1)
+	}
+
+	if e.hdr.Typeflag == tar.TypeReg && !e.captured {
+		if err := idx.load(e); err != nil {
+			return nil, fmt.Errorf("opening %s: %w", name, err)
+		}
+	}
+
+	return &tarFile{fi: e.fi, r: bytes.NewReader(e.data)}, nil
+}
+
+// load streams the tar again to fetch the contents of a single entry that was
+// not captured during indexing.
+func (idx *tarIndex) load(e *tarEntry) error {
+	if idx.reopen == nil {
+		return errors.New("contents were not captured and the tar cannot be reopened")
+	}
+
+	rc, err := idx.reopen()
+	if err != nil {
+		return fmt.Errorf("reopening tar: %w", err)
+	}
+	defer rc.Close()
+
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return fmt.Errorf("entry %q not found on reopen", e.name)
+		}
+		if err != nil {
+			return err
+		}
+		if normalize(hdr.Name) != e.name {
+			continue
+		}
+
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return fmt.Errorf("reading %q: %w", e.name, err)
+		}
+		e.captured = true
+		e.data = data
+		return nil
+	}
+}
+
+// parentDirs yields every proper ancestor of name, shortest first.
+func parentDirs(name string) func(yield func(string) bool) {
+	return func(yield func(string) bool) {
+		for i, v := range name {
+			if v == '/' {
+				if !yield(name[:i]) {
+					return
+				}
+			}
+		}
+	}
+}
+
+type tarFile struct {
+	fi fs.FileInfo
+	r  *bytes.Reader
+}
+
+func (f *tarFile) Stat() (fs.FileInfo, error) { return f.fi, nil }
+func (f *tarFile) Read(p []byte) (int, error) { return f.r.Read(p) }
+func (f *tarFile) Close() error               { return nil }

--- a/pkg/structure/tarindex.go
+++ b/pkg/structure/tarindex.go
@@ -18,15 +18,10 @@ import (
 // entry so that metadata questions (existence, mode, type, directory listings)
 // can be answered without keeping the tar around, and it captures the contents
 // of a chosen set of paths during the single pass over the stream. Contents of
-// any other regular file can still be read on demand, at the cost of streaming
-// the tar a second time via reopen.
+// other files are not available.
 type tarIndex struct {
 	entries map[string]*tarEntry
 	dirs    map[string][]fs.DirEntry
-
-	// reopen returns a fresh reader over the same tar stream. It is only used
-	// when a caller opens a regular file whose contents were not captured.
-	reopen func() (io.ReadCloser, error)
 }
 
 type tarEntry struct {
@@ -46,11 +41,10 @@ func (e *tarEntry) Info() (fs.FileInfo, error) { return e.fi, nil }
 
 // newTarIndex consumes r to completion, indexing every header. Contents are
 // retained for entries whose normalized path is in capture.
-func newTarIndex(r io.Reader, capture map[string]bool, reopen func() (io.ReadCloser, error)) (*tarIndex, error) {
+func newTarIndex(r io.Reader, capture map[string]bool) (*tarIndex, error) {
 	idx := &tarIndex{
 		entries: map[string]*tarEntry{},
 		dirs:    map[string][]fs.DirEntry{},
-		reopen:  reopen,
 	}
 
 	tr := tar.NewReader(r)
@@ -174,49 +168,7 @@ func (idx *tarIndex) open(name string, hops int) (fs.File, error) {
 		return idx.open(path.Join(e.dir, link), hops+1)
 	}
 
-	if e.hdr.Typeflag == tar.TypeReg && !e.captured {
-		if err := idx.load(e); err != nil {
-			return nil, fmt.Errorf("opening %s: %w", name, err)
-		}
-	}
-
-	return &tarFile{fi: e.fi, r: bytes.NewReader(e.data)}, nil
-}
-
-// load streams the tar again to fetch the contents of a single entry that was
-// not captured during indexing.
-func (idx *tarIndex) load(e *tarEntry) error {
-	if idx.reopen == nil {
-		return errors.New("contents were not captured and the tar cannot be reopened")
-	}
-
-	rc, err := idx.reopen()
-	if err != nil {
-		return fmt.Errorf("reopening tar: %w", err)
-	}
-	defer rc.Close()
-
-	tr := tar.NewReader(rc)
-	for {
-		hdr, err := tr.Next()
-		if errors.Is(err, io.EOF) {
-			return fmt.Errorf("entry %q not found on reopen", e.name)
-		}
-		if err != nil {
-			return err
-		}
-		if normalize(hdr.Name) != e.name {
-			continue
-		}
-
-		data, err := io.ReadAll(tr)
-		if err != nil {
-			return fmt.Errorf("reading %q: %w", e.name, err)
-		}
-		e.captured = true
-		e.data = data
-		return nil
-	}
+	return &tarFile{fi: e.fi, r: bytes.NewReader(e.data), captured: e.captured}, nil
 }
 
 // parentDirs yields every proper ancestor of name, shortest first.
@@ -233,10 +185,19 @@ func parentDirs(name string) func(yield func(string) bool) {
 }
 
 type tarFile struct {
-	fi fs.FileInfo
-	r  *bytes.Reader
+	fi       fs.FileInfo
+	r        *bytes.Reader
+	captured bool
 }
 
 func (f *tarFile) Stat() (fs.FileInfo, error) { return f.fi, nil }
-func (f *tarFile) Read(p []byte) (int, error) { return f.r.Read(p) }
 func (f *tarFile) Close() error               { return nil }
+
+// Read returns the captured contents. Reading a regular file whose contents
+// were not requested at index time is an error rather than silently empty.
+func (f *tarFile) Read(p []byte) (int, error) {
+	if !f.captured && f.fi.Mode().IsRegular() {
+		return 0, fmt.Errorf("reading %s: contents were not captured at index time", f.fi.Name())
+	}
+	return f.r.Read(p)
+}

--- a/pkg/structure/tarindex_test.go
+++ b/pkg/structure/tarindex_test.go
@@ -39,13 +39,7 @@ func testTar(t *testing.T) []byte {
 
 func TestTarIndex(t *testing.T) {
 	raw := testTar(t)
-	reopens := 0
-	reopen := func() (io.ReadCloser, error) {
-		reopens++
-		return io.NopCloser(bytes.NewReader(raw)), nil
-	}
-
-	idx, err := newTarIndex(bytes.NewReader(raw), map[string]bool{"etc/os-release": true}, reopen)
+	idx, err := newTarIndex(bytes.NewReader(raw), map[string]bool{"etc/os-release": true, "etc/hosts": true, "usr/lib/libfoo.so": true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,20 +60,6 @@ func TestTarIndex(t *testing.T) {
 	// Captured content is served from memory.
 	if got := readFile("etc/os-release"); got != "PRETTY_NAME=\"Wolfi\"\n" {
 		t.Errorf("os-release = %q", got)
-	}
-	if reopens != 0 {
-		t.Errorf("captured read triggered %d reopens", reopens)
-	}
-
-	// Uncaptured content is fetched by streaming the tar again, once.
-	if got := readFile("etc/hosts"); got != "127.0.0.1 localhost\n" {
-		t.Errorf("hosts = %q", got)
-	}
-	if got := readFile("etc/hosts"); got != "127.0.0.1 localhost\n" {
-		t.Errorf("hosts (second read) = %q", got)
-	}
-	if reopens != 1 {
-		t.Errorf("uncaptured reads triggered %d reopens, want 1", reopens)
 	}
 
 	// Symlinks: relative, absolute, symlinked parent directory, hard link.
@@ -153,17 +133,21 @@ func TestTarIndex(t *testing.T) {
 	}
 }
 
-func TestTarIndexNoReopen(t *testing.T) {
+func TestTarIndexUncaptured(t *testing.T) {
 	raw := testTar(t)
-	idx, err := newTarIndex(bytes.NewReader(raw), nil, nil)
+	idx, err := newTarIndex(bytes.NewReader(raw), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := idx.Open("etc/hosts"); err == nil {
-		t.Error("open of uncaptured file without reopen succeeded, want error")
+	// Opening and statting work without contents, reading does not.
+	f, err := idx.Open("etc/hosts")
+	if err != nil {
+		t.Fatal(err)
 	}
-	// Metadata still works without any content.
-	if fi, err := idx.Stat("etc/hosts"); err != nil || fi.Mode()&permissionMask != 0o666 {
+	if fi, err := f.Stat(); err != nil || fi.Mode()&permissionMask != 0o666 {
 		t.Errorf("stat = %v, %v", fi, err)
+	}
+	if _, err := io.ReadAll(f); err == nil {
+		t.Error("read of uncaptured file succeeded, want error")
 	}
 }

--- a/pkg/structure/tarindex_test.go
+++ b/pkg/structure/tarindex_test.go
@@ -1,0 +1,169 @@
+package structure
+
+import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"slices"
+	"testing"
+)
+
+func testTar(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	write := func(hdr *tar.Header, body string) {
+		hdr.Size = int64(len(body))
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.WriteString(tw, body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(&tar.Header{Name: "./etc/", Typeflag: tar.TypeDir, Mode: 0o755}, "")
+	write(&tar.Header{Name: "etc/os-release", Typeflag: tar.TypeReg, Mode: 0o644}, "PRETTY_NAME=\"Wolfi\"\n")
+	write(&tar.Header{Name: "etc/hosts", Typeflag: tar.TypeReg, Mode: 0o666}, "127.0.0.1 localhost\n")
+	write(&tar.Header{Name: "etc/alias", Typeflag: tar.TypeSymlink, Mode: 0o777, Linkname: "hosts"}, "")
+	write(&tar.Header{Name: "etc/abs", Typeflag: tar.TypeSymlink, Mode: 0o777, Linkname: "/etc/os-release"}, "")
+	write(&tar.Header{Name: "usr/lib/libfoo.so", Typeflag: tar.TypeReg, Mode: 0o755}, "ELF")
+	write(&tar.Header{Name: "lib", Typeflag: tar.TypeSymlink, Mode: 0o777, Linkname: "usr/lib"}, "")
+	write(&tar.Header{Name: "usr/lib/hard", Typeflag: tar.TypeLink, Mode: 0o755, Linkname: "etc/hosts"}, "")
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestTarIndex(t *testing.T) {
+	raw := testTar(t)
+	reopens := 0
+	reopen := func() (io.ReadCloser, error) {
+		reopens++
+		return io.NopCloser(bytes.NewReader(raw)), nil
+	}
+
+	idx, err := newTarIndex(bytes.NewReader(raw), map[string]bool{"etc/os-release": true}, reopen)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readFile := func(name string) string {
+		t.Helper()
+		f, err := idx.Open(name)
+		if err != nil {
+			t.Fatalf("open %q: %v", name, err)
+		}
+		b, err := io.ReadAll(f)
+		if err != nil {
+			t.Fatalf("read %q: %v", name, err)
+		}
+		return string(b)
+	}
+
+	// Captured content is served from memory.
+	if got := readFile("etc/os-release"); got != "PRETTY_NAME=\"Wolfi\"\n" {
+		t.Errorf("os-release = %q", got)
+	}
+	if reopens != 0 {
+		t.Errorf("captured read triggered %d reopens", reopens)
+	}
+
+	// Uncaptured content is fetched by streaming the tar again, once.
+	if got := readFile("etc/hosts"); got != "127.0.0.1 localhost\n" {
+		t.Errorf("hosts = %q", got)
+	}
+	if got := readFile("etc/hosts"); got != "127.0.0.1 localhost\n" {
+		t.Errorf("hosts (second read) = %q", got)
+	}
+	if reopens != 1 {
+		t.Errorf("uncaptured reads triggered %d reopens, want 1", reopens)
+	}
+
+	// Symlinks: relative, absolute, symlinked parent directory, hard link.
+	if got := readFile("etc/alias"); got != "127.0.0.1 localhost\n" {
+		t.Errorf("relative symlink = %q", got)
+	}
+	if got := readFile("etc/abs"); got != "PRETTY_NAME=\"Wolfi\"\n" {
+		t.Errorf("absolute symlink = %q", got)
+	}
+	if got := readFile("lib/libfoo.so"); got != "ELF" {
+		t.Errorf("symlinked dir = %q", got)
+	}
+	if got := readFile("usr/lib/hard"); got != "127.0.0.1 localhost\n" {
+		t.Errorf("hard link = %q", got)
+	}
+
+	// Open reports the mode of the resolved target, Stat does not follow.
+	f, _ := idx.Open("etc/alias")
+	if fi, _ := f.Stat(); fi.Mode()&permissionMask != 0o666 {
+		t.Errorf("open(alias) mode = %o", fi.Mode()&permissionMask)
+	}
+	if fi, err := idx.Stat("etc/alias"); err != nil || fi.Mode()&fs.ModeSymlink == 0 {
+		t.Errorf("stat(alias) = %v, %v, want symlink", fi, err)
+	}
+
+	// Missing files.
+	if _, err := idx.Open("nope"); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("open(nope) = %v, want ErrNotExist", err)
+	}
+	if _, err := idx.Stat("nope"); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("stat(nope) = %v, want ErrNotExist", err)
+	}
+
+	// Directory listings are sorted and include implicit directories.
+	names := func(name string) []string {
+		t.Helper()
+		des, err := idx.ReadDir(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out []string
+		for _, d := range des {
+			out = append(out, d.Name())
+		}
+		return out
+	}
+	if got := names("etc"); !slices.Equal(got, []string{"abs", "alias", "hosts", "os-release"}) {
+		t.Errorf("readdir(etc) = %v", got)
+	}
+	if got := names("usr/lib"); !slices.Equal(got, []string{"hard", "libfoo.so"}) {
+		t.Errorf("readdir(usr/lib) = %v", got)
+	}
+	if got := names("."); !slices.Equal(got, []string{"etc", "lib"}) {
+		t.Errorf("readdir(.) = %v", got)
+	}
+
+	// Walking from the root reaches the explicit directory and its children.
+	var walked []string
+	if err := fs.WalkDir(idx, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		walked = append(walked, p)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{".", "etc", "etc/abs", "etc/alias", "etc/hosts", "etc/os-release", "lib"}
+	if !slices.Equal(walked, want) {
+		t.Errorf("walk = %v, want %v", walked, want)
+	}
+}
+
+func TestTarIndexNoReopen(t *testing.T) {
+	raw := testTar(t)
+	idx, err := newTarIndex(bytes.NewReader(raw), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.Open("etc/hosts"); err == nil {
+		t.Error("open of uncaptured file without reopen succeeded, want error")
+	}
+	// Metadata still works without any content.
+	if fi, err := idx.Stat("etc/hosts"); err != nil || fi.Mode()&permissionMask != 0o666 {
+		t.Errorf("stat = %v, %v", fi, err)
+	}
+}


### PR DESCRIPTION
The structure test used to decompress the whole image into a temp file and then re-read that file so tarfs could index it. Every consumer only needs headers plus the contents of a handful of small files matched by regex, so the uncompressed copy on disk and the second pass over it were pure overhead, and the disk cost scaled with the uncompressed image size times the number of images tested concurrently.

Replace it with a single streaming pass that builds an in-memory fs.FS from the tar headers and captures the bytes of only those paths that a files condition matches by regex. Symlink, hard link, and symlinked-directory resolution mirror the tarfs behavior so existing checks resolve the same way. If a regex path resolves to a file whose contents were not captured, the layer is streamed a second time for that one entry. The targz dependency is dropped.
